### PR TITLE
Stylize error labels on various components

### DIFF
--- a/semantic/src/themes/universe/elements/label.overrides
+++ b/semantic/src/themes/universe/elements/label.overrides
@@ -5,7 +5,10 @@
   float: right;
 }
 
-.field > .input + .label.red {
+.field > .input + .label.red,
+.field > .search + .label.red,
+.field > .dropdown + .label.red,
+.field > .checkbox + .label.red {
   border: 0px;
   font-size: 1em;
   padding-top: 8px;

--- a/stories/form/index.js
+++ b/stories/form/index.js
@@ -202,6 +202,7 @@ const stories = storiesOf('Form', module)
               { key: '5', title: 'Title5', description: 'Description5' }
             ]}
           />
+          <Label basic color="red"><Icon className="universe-exclamation" />This field is required</Label>
         </Form.Field>
         <Form.Group widths={2}>
           <Form.Field error>
@@ -243,19 +244,23 @@ const stories = storiesOf('Form', module)
                 ]}
               >
             </Search>
+            <Label basic color="red"><Icon className="universe-exclamation" />This field is required</Label>
           </Form.Field>
         </Form.Group>
         <Form.Field error>
           <label>Dropdown</label>
           <Dropdown placeholder='Placeholder' selection options={options} onChange={action('changed')} />
+          <Label basic color="red"><Icon className="universe-exclamation" />This field is required</Label>
         </Form.Field>
         <Form.Field error>
           <label>Multiple Dropdown</label>
           <Dropdown placeholder='Placeholder' multiple search selection options={options} onChange={action('changed')} />
+          <Label basic color="red"><Icon className="universe-exclamation" />This field is required</Label>
         </Form.Field>
         <Form.Field label="TextArea" placeholder="Placeholder" control="textarea" error />
         <Form.Field error>
           <Checkbox label="I agree to the Terms and Conditions" />
+          <Label basic color="red"><Icon className="universe-exclamation" />This field is required</Label>
         </Form.Field>
       </Form>
     </Container>


### PR DESCRIPTION
# OVERVIEW:
Add stylized error labels to:
- [x] Search
- [x] Dropdown
- [x] Checkboxes
- [ ] TextArea (couldn't figure this one out, leaving till later)
- [x] Labels (already done previously)

![image](https://user-images.githubusercontent.com/29210883/55822682-1eeb2300-5ace-11e9-8c10-95b66e3fe1e1.png)
