### PR TITLE
Continue scripts if dist directory not present (dont error)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "watch": "cd semantic && gulp build && gulp watch",
     "build": "cd semantic && gulp build",
     "build:icons": "node lib/icons.js",
-    "clean": "rm -r  dist/ && rm semantic*.js semantic*.css",
+    "clean": "rm -r  dist/ && rm semantic*.js semantic*.css || true",
     "preversion": "git add . && git stash && npm run clean",
     "version": "git add package.json package-lock.json && git commit -m \"Version $npm_package_version\" && git push origin master && git checkout release && git pull && git merge origin master --no-edit --strategy-option theirs && cd semantic && gulp build && cd .. && git add --force dist semantic*.js semantic*.css",
     "postversion": "git push && git push --tags && git checkout master",


### PR DESCRIPTION
Simplest way to make the `clean` script more error prone 