### PR TITLE
[WEB-10263] Create Form: Below 768px, set cards to full width + modify padding

### DIFF
--- a/semantic/src/themes/universe/elements/container.overrides
+++ b/semantic/src/themes/universe/elements/container.overrides
@@ -1,0 +1,7 @@
+@media only screen and (max-width : @largestMobileScreen) {
+  .ui.container {
+    width: 100% !important;
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+  }
+}

--- a/semantic/src/themes/universe/views/card.overrides
+++ b/semantic/src/themes/universe/views/card.overrides
@@ -3,6 +3,15 @@
   border-radius: @defaultBorderRadius !important;
 }
 
-.ui.card:first-child {
-  margin-top: 24px;
+@media only screen and (min-width : @tabletBreakpoint) {
+  .ui.card:first-child {
+    margin-top: 24px;
+  }
+}
+
+@media only screen and (max-width : @largestMobileScreen) {
+  .ui.card .content {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
 }


### PR DESCRIPTION
#### Linked to https://github.com/uniiverse/host/pull/70

# OVERVIEW:
When screen width is below 768px, make the card 100% width. Also remove the `margin-top` so that the card appears to "connect" to the progress bar.

![basics](https://user-images.githubusercontent.com/29210883/57731303-5ec29e80-7668-11e9-8f4d-638412a5f427.gif)

---
# SPEC:
![image](https://user-images.githubusercontent.com/29210883/57730795-3a19f700-7667-11e9-99f2-59fec5078f27.png)

![image](https://user-images.githubusercontent.com/29210883/57730754-266e9080-7667-11e9-8256-d9fdf3d477ee.png)
