### PR TITLE
Create design review: Nudge left on left-floated icons within an input component

### DIFF
--- a/semantic/src/themes/universe/elements/input.overrides
+++ b/semantic/src/themes/universe/elements/input.overrides
@@ -126,3 +126,13 @@
 input::placeholder {
   color: @inkLighter !important;
 }
+
+// Icon left
+.ui[class*="left icon"].input > i.icon {
+  left: calc(@borderWidth - 5px);
+}
+
+.ui[class*="left icon"].input > input {
+  padding-left: calc(@iconMargin - 5px) !important;
+  padding-right: @horizontalPadding !important;
+}


### PR DESCRIPTION
### OVERVIEW:
Better left-align any input components with an icon inside of it with input components that only have placeholder text.

#### BEFORE:
![image](https://user-images.githubusercontent.com/29210883/58824754-d9009600-860a-11e9-9b8f-e3e499d258a9.png)

#### AFTER:
![image](https://user-images.githubusercontent.com/29210883/58824648-8fb04680-860a-11e9-9efc-30f2c4182953.png)