### PR TITLE
Fixing icon size on multiple dropdowns

### DIFF
--- a/semantic/src/themes/universe/modules/dropdown.overrides
+++ b/semantic/src/themes/universe/modules/dropdown.overrides
@@ -85,6 +85,10 @@
   border-color: @coralLight;
 }
 
+.ui.multiple.selection.dropdown > .label > .icon {
+  height: auto;
+}
+
 .ui.dropdown .menu {
   top: 100%;
 }


### PR DESCRIPTION
From this:
<img width="217" alt="Screen Shot 2019-06-12 at 1 34 52 PM" src="https://user-images.githubusercontent.com/3308516/59373127-063dfa00-8d17-11e9-902f-b3a1d4128b70.png">


To this:
<img width="218" alt="Screen Shot 2019-06-12 at 1 35 05 PM" src="https://user-images.githubusercontent.com/3308516/59373140-0b9b4480-8d17-11e9-979b-0519f8489c12.png">
