### PR TITLE
Create: Remove override for label ~ small

### DIFF
--- a/semantic/src/themes/universe/collections/form.overrides
+++ b/semantic/src/themes/universe/collections/form.overrides
@@ -95,13 +95,6 @@
       Labels
 ---------------------*/
 
-.ui.form .fields .field > label ~ small {
-  font-size: 12px !important;
-  display: inline-block !important;
-  margin-bottom: 8px !important;
-  color: grey !important;
-}
-
 /*--------------------
       Placeholder
 ---------------------*/


### PR DESCRIPTION
### OVERVIEW:
Remove an override made to target `small` elements that are a direct sibling to a label element contained directly within a `.ui.form. .fields .field`.

This is being removed because there are other `small` elements that I need to target on the Customize page that this target does not address. So instead it is being styled inline versus on the component level.