### PR TITLE
Fix progress bar sizes

### DIFF
--- a/semantic/src/themes/universe/modules/progress.overrides
+++ b/semantic/src/themes/universe/modules/progress.overrides
@@ -1,7 +1,7 @@
-.ui.progress {
+.ui.tiny.progress {
   height: 4px;
 }
 
-.ui.progress .bar {
+.ui.tiny.progress .bar {
   height: 4px;
 }

--- a/stories/progress/index.js
+++ b/stories/progress/index.js
@@ -10,6 +10,14 @@ const stories = storiesOf('Progress', module)
     <Container fluid>
       <Progress success percent={25} />
     </Container>
+  ).add('Sized', () =>
+  <Container>
+    <Progress fluid percent={10} size='tiny'>tiny</Progress>
+    <Progress fluid percent={20} size='small'>small</Progress>
+    <Progress fluid percent={35} size='medium'>medium</Progress>
+    <Progress fluid percent={60} size='large'>large</Progress>
+    <Progress fluid percent={90} size='big'>big</Progress>
+  </Container>
   );
 
 export default stories;


### PR DESCRIPTION
Fix up overrides for progress bar, so not all sizes are overridden.

**Before**
<img width="746" alt="Screen Shot 2020-02-12 at 4 26 15 PM" src="https://user-images.githubusercontent.com/21070073/74379940-aa040c00-4db6-11ea-9687-de3c3bab5781.png">
**After**
<img width="750" alt="Screen Shot 2020-02-12 at 4 26 59 PM" src="https://user-images.githubusercontent.com/21070073/74379952-ad979300-4db6-11ea-835a-78edeebc4648.png">


After this pr is merged, I will cut a pr to bump milkyway version for host and make sure that the progress bar used for create is defined as tiny. 
