### PR TITLE
Remove static width for all icon sizes

### DIFF
--- a/semantic/src/themes/universe/elements/icon.variables
+++ b/semantic/src/themes/universe/elements/icon.variables
@@ -10,8 +10,6 @@
 
 /* Icon Variables */
 @opacity: 1;
-@width: 24px;
-@height: 24px;
 @distanceFromText: 0.25rem;
 @grey: @inkLight;
 

--- a/stories/icon/index.js
+++ b/stories/icon/index.js
@@ -294,6 +294,39 @@ const stories = storiesOf('Icon', module)
         </Table.Body>
       </Table>
     </Container>
-  );
+  ).add('Sized icons', () =>
+<Container fluid>
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Classname</Table.HeaderCell>
+            <Table.HeaderCell>Value</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>universe-1 size="tiny"</Table.Cell>
+            <Table.Cell><Icon size="tiny" className="universe-1" /></Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>universe-1 size="small"</Table.Cell>
+            <Table.Cell><Icon size="small" className="universe-1" /></Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>universe-1 size="large"</Table.Cell>
+            <Table.Cell><Icon size="large" className="universe-1" /></Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>universe-1 size="huge"</Table.Cell>
+            <Table.Cell><Icon size="huge" className="universe-1" /></Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>universe-1 size="massive"</Table.Cell>
+            <Table.Cell><Icon size="massive" className="universe-1" /></Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </Container>
+);
 
 export default stories;


### PR DESCRIPTION
Reason for change: Hard to style and position that all have a width of 24px for all sizes.


There are also variables that set icon width that don't immediately make sense to me, but there are a lot of them, so I assume there is a reason (Also they use a unit `em` to change size relative to font size, which behaves fine)

```
/* Maximum Glyph Width of Icon */
@iconWidth : 1.18em;
```

**Before**
<img width="1105" alt="Screen Shot 2020-03-04 at 11 41 01 AM" src="https://user-images.githubusercontent.com/21070073/75903110-18187d80-5e0f-11ea-9e2d-9f62ee31eeb3.png">

**After**
<img width="1101" alt="Screen Shot 2020-03-04 at 11 41 08 AM" src="https://user-images.githubusercontent.com/21070073/75903123-1b136e00-5e0f-11ea-8596-cf162da6444a.png">
