### PR TITLE
Remove padding top from step

### DIFF
--- a/semantic/src/themes/universe/elements/step.overrides
+++ b/semantic/src/themes/universe/elements/step.overrides
@@ -2,7 +2,3 @@
 .ui.steps .step.completed .content {
   color: @completedColor;
 }
-
-.ui.steps:not(.vertical) .step > .icon {
-  padding-top: 4px;
-}


### PR DESCRIPTION
Necessary change to remedy Step icons breaking on create after Version 0.0.68
**Before**
<img width="941" alt="Screen Shot 2020-03-09 at 10 33 43 AM" src="https://user-images.githubusercontent.com/21070073/76223188-b16dd800-61f1-11ea-9d28-aeba539580d9.png">

**After**
<img width="941" alt="Screen Shot 2020-03-09 at 10 33 20 AM" src="https://user-images.githubusercontent.com/21070073/76223214-b3379b80-61f1-11ea-93cb-adb24ffdd0fc.png">
