### PR TITLE
Remove use of !important

### DIFF
--- a/semantic/src/themes/universe/modules/dropdown.overrides
+++ b/semantic/src/themes/universe/modules/dropdown.overrides
@@ -30,7 +30,7 @@
   font-style: normal;
   text-align: center;
   color: @inkLighter;
-  padding: 11px 8px !important;
+  padding: 11px 8px;
 }
 
 .ui.dropdown > .dropdown.icon:before {


### PR DESCRIPTION
This padding is likely completely useless and was fixing an alignment issue with icons that was fixed a few months back. My first reaction was to remove the padding all together, but just removing the !important tag will solve my problem + will make it shippable faster without much testing to be done.

If we want to remove this line here is the difference it makes ...
With padding
<img width="346" alt="Screen Shot 2020-05-19 at 11 27 13 AM" src="https://user-images.githubusercontent.com/21070073/82347645-e6529400-99c5-11ea-9ced-a95c3d358990.png">
Without padding
<img width="353" alt="Screen Shot 2020-05-19 at 11 27 18 AM" src="https://user-images.githubusercontent.com/21070073/82347649-e6eb2a80-99c5-11ea-91a8-d7da60bc24c2.png">


Random padding that I can't override
<img width="689" alt="Screen Shot 2020-05-19 at 11 35 00 AM" src="https://user-images.githubusercontent.com/21070073/82347358-7e9c4900-99c5-11ea-9f99-3dd2de9a9d9e.png">
No random padding
<img width="681" alt="Screen Shot 2020-05-19 at 11 35 06 AM" src="https://user-images.githubusercontent.com/21070073/82347360-7f34df80-99c5-11ea-9891-76ab09be0b6f.png">
