### PR TITLE
Remove !important padding on dropdown item

### DIFF
--- a/semantic/src/definitions/modules/dropdown.less
+++ b/semantic/src/definitions/modules/dropdown.less
@@ -126,7 +126,7 @@
   font-size: @itemFontSize;
   color: @itemColor;
 
-  padding: @itemPadding !important;
+  padding: @itemPadding;
   font-size: @itemFontSize;
   text-transform: @itemTextTransform;
   font-weight: @itemFontWeight;

--- a/stories/dropdown/index.js
+++ b/stories/dropdown/index.js
@@ -150,6 +150,14 @@ const stories = storiesOf('Dropdown', module)
         <Dropdown placeholder='Select' multiple search selection options={imageOptions} onChange={action('changed')} error />
       </p>
     </Container>
+  ).add('Dropdown Menu', () =>
+    <Dropdown text="Filter" labeled>
+      <Dropdown.Menu>
+        <Dropdown.Item text="Option 1" />
+        <Dropdown.Item text="Option 2" />
+        <Dropdown.Item text="Option 3"/>
+      </Dropdown.Menu>
+    </Dropdown>
   );
 
 export default stories;


### PR DESCRIPTION
Host
**Before**
<img width="512" alt="Screen Shot 2020-05-25 at 11 22 30 AM" src="https://user-images.githubusercontent.com/21070073/82826759-bb5fb880-9e7b-11ea-87b9-ccbe692f8ca4.png">
**After**
<img width="509" alt="Screen Shot 2020-05-25 at 11 22 26 AM" src="https://user-images.githubusercontent.com/21070073/82826763-bc90e580-9e7b-11ea-9002-e0bd81f929c9.png">

Story
**Before**
<img width="136" alt="Screen Shot 2020-05-25 at 11 05 51 AM" src="https://user-images.githubusercontent.com/21070073/82826833-dd593b00-9e7b-11ea-9059-9d349d880353.png">

**After**
<img width="136" alt="Screen Shot 2020-05-25 at 11 05 51 AM" src="https://user-images.githubusercontent.com/21070073/82826839-dfbb9500-9e7b-11ea-93f7-c3f63fd1f112.png">
