### PR TITLE
Add clearable icon to dropdown

### DIFF
--- a/semantic/src/themes/universe/modules/dropdown.overrides
+++ b/semantic/src/themes/universe/modules/dropdown.overrides
@@ -41,6 +41,10 @@
   content: '\e903';
 }
 
+.ui.dropdown > .clear.icon:before {
+  content: "\e904";
+}
+
 .ui.dropdown > .ui.label > i.icon.delete:before {
   font-family: 'Dropdown';
   content: '\e904';

--- a/stories/dropdown/index.js
+++ b/stories/dropdown/index.js
@@ -158,6 +158,15 @@ const stories = storiesOf('Dropdown', module)
         <Dropdown.Item text="Option 3"/>
       </Dropdown.Menu>
     </Dropdown>
+  ).add('Clearable', () =>
+  <Container>
+    <p>
+      <Dropdown placeholder='Select' selection options={options} clearable onChange={action('changed')} />
+    </p>
+    <p>
+      <Dropdown placeholder='Select' selection options={options} clearable onChange={action('changed')} error />
+    </p>
+  </Container>
   );
 
 export default stories;


### PR DESCRIPTION
Fixes missing a close icon for clearable dropdowns
**Before**
<img width="235" alt="Screen Shot 2020-05-25 at 11 24 49 AM" src="https://user-images.githubusercontent.com/21070073/82828531-41313300-9e7f-11ea-8994-1ec62f5357ac.png">

**After**
<img width="229" alt="Screen Shot 2020-05-25 at 11 56 03 AM" src="https://user-images.githubusercontent.com/21070073/82828509-35457100-9e7f-11ea-9083-7803996a6158.png">
