### PR TITLE
Fix focus styles

### DIFF
--- a/semantic/src/definitions/modules/checkbox.less
+++ b/semantic/src/definitions/modules/checkbox.less
@@ -214,7 +214,6 @@
 .ui.checkbox input:not([type=radio]):indeterminate:focus ~ label:before,
 .ui.checkbox input:checked:focus ~ .box:before,
 .ui.checkbox input:checked:focus ~ label:before  {
-  background: @checkboxActiveFocusBackground;
   border-color: @checkboxActiveFocusBorderColor;
 }
 .ui.checkbox input:not([type=radio]):indeterminate:focus ~ .box:after,
@@ -345,10 +344,6 @@
 }
 
 /* Active Focus */
-.ui.radio.checkbox input:focus:checked ~ .box:before,
-.ui.radio.checkbox input:focus:checked ~ label:before {
-  background-color: @radioActiveFocusBackground;
-}
 .ui.radio.checkbox input:focus:checked ~ .box:after,
 .ui.radio.checkbox input:focus:checked ~ label:after {
   background-color: @radioActiveFocusBulletColor;

--- a/semantic/src/definitions/modules/checkbox.less
+++ b/semantic/src/definitions/modules/checkbox.less
@@ -210,16 +210,15 @@
   Active Focus
 ---------------*/
 
-.ui.checkbox input:not([type=radio]):indeterminate:focus ~ .box:before,
-.ui.checkbox input:not([type=radio]):indeterminate:focus ~ label:before,
-.ui.checkbox input:checked:focus ~ .box:before,
-.ui.checkbox input:checked:focus ~ label:before  {
+.ui.checkbox input:focus ~ .box:before,
+.ui.checkbox input:focus ~ label:before  {
+  background: @checkboxActiveFocusBackground;
   border-color: @checkboxActiveFocusBorderColor;
 }
 .ui.checkbox input:not([type=radio]):indeterminate:focus ~ .box:after,
 .ui.checkbox input:not([type=radio]):indeterminate:focus ~ label:after,
-.ui.checkbox input:checked:focus ~ .box:after,
-.ui.checkbox input:checked:focus ~ label:after {
+.ui.checkbox input:focus ~ .box:after,
+.ui.checkbox input:focus ~ label:after {
   color: @checkboxActiveFocusCheckColor;
 }
 
@@ -344,6 +343,12 @@
 }
 
 /* Active Focus */
+.ui.radio.checkbox input:focus ~ .box:before,
+.ui.radio.checkbox input:focus ~ label:before {
+  background-color: @radioActiveFocusBackground;
+  border-color: @checkboxActiveFocusBorderColor;
+}
+
 .ui.radio.checkbox input:focus:checked ~ .box:after,
 .ui.radio.checkbox input:focus:checked ~ label:after {
   background-color: @radioActiveFocusBulletColor;

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -10,6 +10,7 @@ function loadStories() {
     'button/group',
     'card',
     'checkbox',
+    'radio',
     'dropdown',
     'form',
     'grid',

--- a/stories/radio/index.js
+++ b/stories/radio/index.js
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import { Container, Radio, Form } from 'semantic-ui-react';
+
 
 const stories = storiesOf('Radio', module)
   .add('Default', () =>
@@ -12,6 +13,40 @@ const stories = storiesOf('Radio', module)
       <p><Radio label="Checked" checked /></p>
       <p><Radio label="Disabled" disabled /></p>
     </Container>
+  )
+  .add('Controlled Radio Group', () => {
+    const [radioSelection, setRadioSelection] = useState(1);
+    const handleChange = (e, { value }) => setRadioSelection(value)
+    return (
+      <Container fluid >
+        <div>
+          <Radio
+            name='radioGroup'
+            value={1}
+            checked={radioSelection == 1}
+            onChange={handleChange}
+            label="Radio 1" />
+        </div>
+        <div>
+          <Radio
+            name='radioGroup'
+            value={2}
+            checked={radioSelection == 2}
+            onChange={handleChange}
+            label="Radio 2" />
+        </div>
+        <div>
+          <Radio
+            name='radioGroup'
+            value={3}
+            checked={radioSelection == 3}
+            onChange={handleChange}
+            label="Radio 3" />
+        </div>
+      </Container>
+    )
+  }
+
   )
   .add('Toggle', () =>
     <Container fluid>

--- a/stories/radio/index.js
+++ b/stories/radio/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import { Container, Radio, Form } from 'semantic-ui-react';
+
+const stories = storiesOf('Radio', module)
+  .add('Default', () =>
+    <Container fluid>
+      <p><Radio label="Unchecked" /></p>
+      <p><Radio label="Checked" checked /></p>
+      <p><Radio label="Disabled" disabled /></p>
+    </Container>
+  )
+  .add('Toggle', () =>
+    <Container fluid>
+      <p><Radio toggle label="Toggle" /></p>
+      <p><Radio toggle checked={false} disabled label="Unchecked disabled" /></p>
+      <p><Radio toggle checked={true} disabled label="Checked disabled" /></p>
+    </Container>
+  );
+
+export default stories;


### PR DESCRIPTION
Only concern is that radio buttons don't have a focus state when they are checked, which make this very unaccessible to navigate the buttons using keyboard. This will need to be addressed at a later date.
Radio 3 is focused, If Radio 1 was focused, there wouldn't be a change in styles for it.
<img width="99" alt="Screen Shot 2020-10-29 at 3 53 24 PM" src="https://user-images.githubusercontent.com/21070073/97625625-213e0680-19ff-11eb-8399-5957244f5c51.png">
