### PR TITLE
Remove !important from bordered icon

### DIFF
--- a/semantic/src/definitions/elements/icon.less
+++ b/semantic/src/definitions/elements/icon.less
@@ -186,7 +186,7 @@ i.bordered.icon {
 
   width: @borderedSize;
   height: @borderedSize;
-  padding: @borderedVerticalPadding @borderedHorizontalPadding !important;
+  padding: @borderedVerticalPadding @borderedHorizontalPadding;
   box-shadow: @borderedShadow;
 }
 i.bordered.inverted.icon {

--- a/stories/icon/index.js
+++ b/stories/icon/index.js
@@ -327,6 +327,23 @@ const stories = storiesOf('Icon', module)
         </Table.Body>
       </Table>
     </Container>
+  ).add('Bordered inverted link icon', () =>
+    <Container fluid>
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Classname</Table.HeaderCell>
+            <Table.HeaderCell>Value</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>universe-1 size="large" bordered inverted link</Table.Cell>
+            <Table.Cell><Icon size="large" bordered inverted link className="universe-link" /></Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </Container>
 );
 
 export default stories;


### PR DESCRIPTION
Added the use case to story book to make sure that bordered icons have not been negatively affected.
With !important
<img width="270" alt="Screen Shot 2020-12-03 at 11 27 23 AM" src="https://user-images.githubusercontent.com/21070073/101064506-1298c100-3562-11eb-86b0-7e23b60df312.png">
<img width="62" alt="Screen Shot 2020-12-03 at 11 27 28 AM" src="https://user-images.githubusercontent.com/21070073/101064312-d9605100-3561-11eb-9670-dd01e1f16e39.png">
Without !important (Allows  css to override semantic react styling for padding, when a width/height of icon is changed
<img width="160" alt="Screen Shot 2020-12-03 at 11 27 51 AM" src="https://user-images.githubusercontent.com/21070073/101064489-0ca2e000-3562-11eb-8621-108d27f109fa.png">
<img width="69" alt="Screen Shot 2020-12-03 at 11 27 53 AM" src="https://user-images.githubusercontent.com/21070073/101064335-e1b88c00-3561-11eb-838d-9758c4b8f1af.png">
