### PR TITLE
[Rate Upgrades] Pamphlet

### DIFF
--- a/components/Pamphlet/Pamphlet.jsx
+++ b/components/Pamphlet/Pamphlet.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import styles from './Pamphlet.less';
 
 export const Pamphlet = props => {
-  const { title, subtitle, description, imageUrl, children, buttonText } = props;
+  const { title, subtitle, description, imageUrl, children, buttonText, handleClick } = props;
 
   return (
     <>
@@ -21,7 +21,7 @@ export const Pamphlet = props => {
 
           <div className={styles.container}>{children}</div>
 
-          <Button primary className={styles.button}>
+          <Button primary className={styles.button} onClick={handleClick}>
             {buttonText}
           </Button>
         </div>
@@ -37,4 +37,5 @@ Pamphlet.propTypes = {
   imageUrl: PropTypes.string.isRequired,
   buttonText: PropTypes.string.isRequired,
   children: PropTypes.element.isRequired,
+  handleClick: PropTypes.func.isRequired
 };

--- a/components/Pamphlet/Pamphlet.jsx
+++ b/components/Pamphlet/Pamphlet.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import {
   Button,
   Container,
@@ -13,7 +13,7 @@ export const Pamphlet = (props) => {
   const { title, priceText, description } = props;
 
   return (
-    <div>
+    <Fragment>
       <Container className={styles.container}>
         <Image
           className={styles.bannerImage}
@@ -22,7 +22,7 @@ export const Pamphlet = (props) => {
 
         <div className={styles.containerBody}>
           <Header
-            as="h3"
+            as='h3'
             className={styles.title}>
             {title}
           </Header>
@@ -31,7 +31,7 @@ export const Pamphlet = (props) => {
 
           <div className={styles.listContainer}>
             <List>
-              <p className={styles.listDescription}>{"⭐️ You will get:"}</p>
+              <p className={styles.listDescription}>{'⭐️ You will get:'}</p>
 
               <ul className={styles.listItems}>
                 {props.upgradeOptions.map((option, i) => (<li key={i}>{option}</li>))}
@@ -44,6 +44,6 @@ export const Pamphlet = (props) => {
           </Button>
         </div>
       </Container>
-    </div>
+    </Fragment>
   );
 };

--- a/components/Pamphlet/Pamphlet.jsx
+++ b/components/Pamphlet/Pamphlet.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import styles from './Pamphlet.less';
 
 export const Pamphlet = props => {
-  const { title, subtitle, description, imageUrl, children, buttonText, handleClick } = props;
+  const { title, subtitle, description, imageUrl, children, buttonText, onButtonClick } = props;
 
   return (
     <>
@@ -21,7 +21,7 @@ export const Pamphlet = props => {
 
           <div className={styles.container}>{children}</div>
 
-          <Button primary className={styles.button} onClick={handleClick}>
+          <Button primary className={styles.button} onClick={onButtonClick}>
             {buttonText}
           </Button>
         </div>
@@ -37,5 +37,5 @@ Pamphlet.propTypes = {
   imageUrl: PropTypes.string.isRequired,
   buttonText: PropTypes.string.isRequired,
   children: PropTypes.element.isRequired,
-  handleClick: PropTypes.func.isRequired
+  onButtonClick: PropTypes.func.isRequired
 };

--- a/components/Pamphlet/Pamphlet.jsx
+++ b/components/Pamphlet/Pamphlet.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import {
   Button,
   Container,
@@ -13,7 +13,7 @@ export const Pamphlet = (props) => {
   const { title, priceText, description } = props;
 
   return (
-    <Fragment>
+    <>
       <Container className={styles.container}>
         <Image
           className={styles.bannerImage}
@@ -44,6 +44,6 @@ export const Pamphlet = (props) => {
           </Button>
         </div>
       </Container>
-    </Fragment>
+    </>
   );
 };

--- a/components/Pamphlet/Pamphlet.jsx
+++ b/components/Pamphlet/Pamphlet.jsx
@@ -1,49 +1,39 @@
 import React from 'react';
-import {
-  Button,
-  Container,
-  Header,
-  Image,
-  List
-} from 'semantic-ui-react';
+import { Button, Container, Header, Image } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
 
 import styles from './Pamphlet.less';
 
-export const Pamphlet = (props) => {
-  const { title, priceText, description, imageUrl, upgradeOptions, buttonText } = props;
+export const Pamphlet = props => {
+  const { title, subtitle, description, imageUrl, children, buttonText } = props;
 
   return (
     <>
       <Container className={styles.container}>
-        <Image
-          className={styles.bannerImage}
-          src={imageUrl}
-        />
+        <Image className={styles.bannerImage} src={imageUrl} />
 
         <div className={styles.containerBody}>
-          <Header
-            as='h3'
-            className={styles.title}>
+          <Header as="h3" className={styles.title}>
             {title}
           </Header>
-          <p className={styles.priceText}>{priceText}</p>
+          <p className={styles.subtitle}>{subtitle}</p>
           <p className={styles.description}>{description}</p>
 
-          <div className={styles.listContainer}>
-            <List>
-              <p className={styles.listDescription}>{'⭐️ You will get:'}</p>
+          <div className={styles.container}>{children}</div>
 
-              <ul className={styles.listItems}>
-                {upgradeOptions.map((option, i) => (<li key={i}>{option}</li>))}
-              </ul>
-            </List>
-          </div>
-
-          <Button primary className={styles.upgradeButton}>
+          <Button primary className={styles.button}>
             {buttonText}
           </Button>
         </div>
       </Container>
     </>
   );
+};
+
+Pamphlet.propTypes = {
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  imageUrl: PropTypes.string.isRequired,
+  children: PropTypes.element.isRequired,
 };

--- a/components/Pamphlet/Pamphlet.jsx
+++ b/components/Pamphlet/Pamphlet.jsx
@@ -5,17 +5,17 @@ import {
   Header,
   Image,
   List
- } from 'semantic-ui-react';
+} from 'semantic-ui-react';
 
 import styles from './Pamphlet.less';
 
 export const Pamphlet = (props) => {
-  const { header, price, description } = props;
+  const { title, priceText, description } = props;
 
   return (
     <div>
       <Container className={styles.container}>
-        <Image 
+        <Image
           className={styles.bannerImage}
           src={props.imageUrl}
         />
@@ -23,10 +23,10 @@ export const Pamphlet = (props) => {
         <div className={styles.containerBody}>
           <Header
             as="h3"
-            className={styles.header}>
-              {header}
+            className={styles.title}>
+            {title}
           </Header>
-          <p className={styles.priceDifference}>{`Only $${price}.00 extra per ticket`}</p>
+          <p className={styles.priceDifference}>{priceText}</p>
           <p className={styles.description}>{description}</p>
 
           <div className={styles.listContainer}>

--- a/components/Pamphlet/Pamphlet.jsx
+++ b/components/Pamphlet/Pamphlet.jsx
@@ -20,7 +20,7 @@ export const Pamphlet = (props) => {
           src={props.imageUrl}
         />
 
-        <Container className={styles.containerBody}>
+        <div className={styles.containerBody}>
           <Header
             as="h3"
             className={styles.header}>
@@ -42,7 +42,7 @@ export const Pamphlet = (props) => {
           <Button primary className={styles.upgradeButton}>
             {props.buttonText}
           </Button>
-        </Container>
+        </div>
       </Container>
     </div>
   );

--- a/components/Pamphlet/Pamphlet.jsx
+++ b/components/Pamphlet/Pamphlet.jsx
@@ -10,14 +10,14 @@ import {
 import styles from './Pamphlet.less';
 
 export const Pamphlet = (props) => {
-  const { title, priceText, description } = props;
+  const { title, priceText, description, imageUrl, upgradeOptions, buttonText } = props;
 
   return (
     <>
       <Container className={styles.container}>
         <Image
           className={styles.bannerImage}
-          src={props.imageUrl}
+          src={imageUrl}
         />
 
         <div className={styles.containerBody}>
@@ -26,7 +26,7 @@ export const Pamphlet = (props) => {
             className={styles.title}>
             {title}
           </Header>
-          <p className={styles.priceDifference}>{priceText}</p>
+          <p className={styles.priceText}>{priceText}</p>
           <p className={styles.description}>{description}</p>
 
           <div className={styles.listContainer}>
@@ -34,13 +34,13 @@ export const Pamphlet = (props) => {
               <p className={styles.listDescription}>{'⭐️ You will get:'}</p>
 
               <ul className={styles.listItems}>
-                {props.upgradeOptions.map((option, i) => (<li key={i}>{option}</li>))}
+                {upgradeOptions.map((option, i) => (<li key={i}>{option}</li>))}
               </ul>
             </List>
           </div>
 
           <Button primary className={styles.upgradeButton}>
-            {props.buttonText}
+            {buttonText}
           </Button>
         </div>
       </Container>

--- a/components/Pamphlet/Pamphlet.jsx
+++ b/components/Pamphlet/Pamphlet.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {
+  Button,
+  Container,
+  Header,
+  Image,
+  List
+ } from 'semantic-ui-react';
+
+import styles from './Pamphlet.less';
+
+export const Pamphlet = (props) => {
+  const { header, price, description } = props;
+
+  return (
+    <div>
+      <Container className={styles.container}>
+        <Image 
+          className={styles.bannerImage}
+          src={props.imageUrl}
+        />
+
+        <Container className={styles.containerBody}>
+          <Header
+            as="h3"
+            className={styles.header}>
+              {header}
+          </Header>
+          <p className={styles.priceDifference}>{`Only $${price}.00 extra per ticket`}</p>
+          <p className={styles.description}>{description}</p>
+
+          <div className={styles.listContainer}>
+            <List>
+              <p className={styles.listDescription}>{"⭐️ You will get:"}</p>
+
+              <ul className={styles.listItems}>
+                {props.upgradeOptions.map((option, i) => (<li key={i}>{option}</li>))}
+              </ul>
+            </List>
+          </div>
+
+          <Button primary className={styles.upgradeButton}>
+            {props.buttonText}
+          </Button>
+        </Container>
+      </Container>
+    </div>
+  );
+};

--- a/components/Pamphlet/Pamphlet.jsx
+++ b/components/Pamphlet/Pamphlet.jsx
@@ -35,5 +35,6 @@ Pamphlet.propTypes = {
   subtitle: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   imageUrl: PropTypes.string.isRequired,
+  buttonText: PropTypes.string.isRequired,
   children: PropTypes.element.isRequired,
 };

--- a/components/Pamphlet/Pamphlet.less
+++ b/components/Pamphlet/Pamphlet.less
@@ -19,12 +19,10 @@
 
 .containerBody {
   padding: 30px;
-  width: 100%;
 }
 
 .description {
   margin: 24px 0;
-  width: 100%;
 }
 
 .listContainer {
@@ -33,7 +31,6 @@
 
 .listDescription {
   margin-bottom: 0px;
-  width: 100%;
 }
 
 .listItems { 

--- a/components/Pamphlet/Pamphlet.less
+++ b/components/Pamphlet/Pamphlet.less
@@ -1,0 +1,73 @@
+.container {
+  background: #fff;
+  width: 459px !important;
+}
+
+.header {
+  font-family: Circular Pro, "Circular Pro", sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 20px;
+  line-height: 28px;
+}
+
+.bannerImage {
+  height: 200px;
+  width: 100%;
+  object-fit: cover;
+}
+
+.containerBody {
+  padding: 30px;
+  width: 100%;
+}
+
+.description {
+  margin: 24px 0;
+  width: 100%;
+}
+
+.listContainer {
+  margin-bottom: 36px;
+}
+
+.listDescription {
+  margin-bottom: 0px;
+  width: 100%;
+}
+
+.listItems { 
+  margin: 2px 0 20px;
+  padding-left: 20px; 
+  color: #1C232B;
+  font-family: 'Graphik', 'Helvetica', helvetica, arial, sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+
+  li {
+    padding-left: 4px;
+  }
+
+  li::marker {
+    font-size: 9px;
+  }
+}
+
+.priceDifference {
+  color: #6F7881;
+  /* Desktop/Regular bold */
+  font-family: 'Graphik', 'Helvetica', helvetica, arial, sans-serif;
+  font-style: 'normal';
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 20px;
+}
+
+.upgradeButton {
+  width: 367px;
+  height: 28px;
+  font-size: 13px;
+  box-sizing: content-box;
+}

--- a/components/Pamphlet/Pamphlet.less
+++ b/components/Pamphlet/Pamphlet.less
@@ -4,7 +4,7 @@
 }
 
 .title {
-  font-family: Circular Pro, "Circular Pro", sans-serif;
+  font-family: Circular Pro, 'Circular Pro', sans-serif;
   font-style: normal;
   font-weight: 400;
   font-size: 20px;
@@ -33,9 +33,9 @@
   margin-bottom: 0px;
 }
 
-.listItems { 
+.listItems {
   margin: 2px 0 20px;
-  padding-left: 20px; 
+  padding-left: 20px;
   color: #1C232B;
   font-family: 'Graphik', 'Helvetica', helvetica, arial, sans-serif;
   font-style: normal;

--- a/components/Pamphlet/Pamphlet.less
+++ b/components/Pamphlet/Pamphlet.less
@@ -3,7 +3,7 @@
   width: 459px !important;
 }
 
-.header {
+.title {
   font-family: Circular Pro, "Circular Pro", sans-serif;
   font-style: normal;
   font-weight: 400;

--- a/components/Pamphlet/Pamphlet.less
+++ b/components/Pamphlet/Pamphlet.less
@@ -25,7 +25,7 @@
   margin: 24px 0;
 }
 
-.listContainer {
+.container {
   margin-bottom: 36px;
 }
 
@@ -52,7 +52,7 @@
   }
 }
 
-.priceText {
+.subtitle {
   color: #6F7881;
   /* Desktop/Regular bold */
   font-family: 'Graphik', 'Helvetica', helvetica, arial, sans-serif;
@@ -62,7 +62,7 @@
   line-height: 20px;
 }
 
-.upgradeButton {
+.button {
   width: 367px;
   height: 28px;
   font-size: 13px;

--- a/components/Pamphlet/Pamphlet.less
+++ b/components/Pamphlet/Pamphlet.less
@@ -52,7 +52,7 @@
   }
 }
 
-.priceDifference {
+.priceText {
   color: #6F7881;
   /* Desktop/Regular bold */
   font-family: 'Graphik', 'Helvetica', helvetica, arial, sans-serif;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "milkyway",
-  "version": "0.1.93",
+  "version": "0.1.99",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "lodash.debounce": "^4.0.8",
     "moment": "^2.29.1",
+    "prop-types": "^15.8.1",
     "react-dates": "^21.8.0",
     "react-intl": "^5.20.4",
     "styled-components": "^5.3.0"

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -20,6 +20,7 @@ function loadStories() {
     'message',
     'modal',
     'navbar',
+    'pamphlet',
     'progress',
     'search',
     'segment',

--- a/stories/pamphlet/index.js
+++ b/stories/pamphlet/index.js
@@ -9,6 +9,10 @@ import { title, subtitle, description, imageUrl, upgradeOptions, buttonText } fr
 
 const stories = storiesOf('Pamphlet', module);
 
+const alertClick = () => {
+  alert('clicked')
+}
+
 stories.add('Rate Upgrades', () => (
   <React.Fragment>
     <Pamphlet
@@ -17,6 +21,7 @@ stories.add('Rate Upgrades', () => (
       description={text('Description', description)}
       imageUrl={text('image URL', imageUrl)}
       buttonText={text('Button text', buttonText)}
+      handleClick={alertClick}
     >
       <List>
         <p className={styles.listDescription}>{'⭐️ You will get:'}</p>

--- a/stories/pamphlet/index.js
+++ b/stories/pamphlet/index.js
@@ -20,7 +20,6 @@ stories.add('Rate Upgrades', () => (
     >
       <List>
         <p className={styles.listDescription}>{'⭐️ You will get:'}</p>
-
         <ul className={styles.listItems}>
           {array('Upgrade options', upgradeOptions).map((option, i) => (
             <li key={i}>{option}</li>

--- a/stories/pamphlet/index.js
+++ b/stories/pamphlet/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { storiesOf } from '@storybook/react';
-import { array, text } from "@storybook/addon-knobs";
+import { array, text } from '@storybook/addon-knobs';
 
 import { Pamphlet } from '../../components/Pamphlet/Pamphlet';
 import {
@@ -19,11 +19,11 @@ stories
   .add('Rate Upgrades', () => (
     <React.Fragment>
       <Pamphlet
-        title={text("Title", title)}
+        title={text('Title', title)}
         price={priceText}
-        description={text("Description", description)}
-        upgradeOptions={array("Upgrade options", upgradeOptions)}
-        imageUrl={text("image URL", imageUrl)}
+        description={text('Description', description)}
+        upgradeOptions={array('Upgrade options', upgradeOptions)}
+        imageUrl={text('image URL', imageUrl)}
         buttonText={buttonText}
       />
     </React.Fragment>

--- a/stories/pamphlet/index.js
+++ b/stories/pamphlet/index.js
@@ -16,7 +16,7 @@ stories.add('Rate Upgrades', () => (
       subtitle={text('Subtitle', subtitle)}
       description={text('Description', description)}
       imageUrl={text('image URL', imageUrl)}
-      buttonText={buttonText}
+      buttonText={text('Button text', buttonText)}
     >
       <List>
         <p className={styles.listDescription}>{'⭐️ You will get:'}</p>

--- a/stories/pamphlet/index.js
+++ b/stories/pamphlet/index.js
@@ -4,25 +4,16 @@ import { storiesOf } from '@storybook/react';
 import { array, text } from "@storybook/addon-knobs";
 
 import { Pamphlet } from '../../components/Pamphlet/Pamphlet';
+import {
+  title,
+  priceText,
+  description,
+  imageUrl,
+  upgradeOptions,
+  buttonText
+} from './preview-variables';
 
 const stories = storiesOf('Pamphlet', module);
-
-const title = "VIP ticket upgrade - Best experience"
-const priceText = "Only $40.00 extra per ticket"
-const description = "🎉 Enhance your experience at the event!"
-const imageUrl = "https://www.tastingtable.com/img/gallery/11-cocktails-to-try-if-you-like-drinking-gin/intro-1640186734.webp"
-const upgradeOptions = [
-  "Priority access",
-  "Flexibility to arrive +/- 1hr of your time",
-  "Limited edition poster",
-  "greet and meetLimited edition cushion",
-  "VIP souvenir laminate",
-  "Priority access",
-  "Flexibility to arrive +/- 1hr of your time",
-  "Free available T-shirt while products last",
-  "Special seating"
-]
-const buttonText = "UPGRADE ALL TICKETS"
 
 stories
   .add('Rate Upgrades', () => (

--- a/stories/pamphlet/index.js
+++ b/stories/pamphlet/index.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+import { array, text } from "@storybook/addon-knobs";
+
+import { Pamphlet } from '../../components/Pamphlet/Pamphlet';
+
+const stories = storiesOf('Pamphlet', module);
+
+const header = "VIP ticket upgrade - Best experience"
+const price = 40.00
+const description = "🎉 Enhance your experience at the event!"
+const imageUrl = "https://www.tastingtable.com/img/gallery/11-cocktails-to-try-if-you-like-drinking-gin/intro-1640186734.webp"
+const upgradeOptions = [
+  "Priority access",
+  "Flexibility to arrive +/- 1hr of your time",
+  "Limited edition poster",
+  "greet and meetLimited edition cushion",
+  "VIP souvenir laminate",
+  "Priority access",
+  "Flexibility to arrive +/- 1hr of your time",
+  "Free available T-shirt while products last",
+  "Special seating"
+]
+const buttonText = "UPGRADE ALL TICKETS"
+
+stories
+  .add('Rate Upgrades', () => (
+    <React.Fragment>
+      <Pamphlet
+        header={text("Header", header)}
+        price={price}
+        description={text("Description", description)}
+        upgradeOptions={array("Upgrade options", upgradeOptions)}
+        imageUrl={text("image URL", imageUrl)}
+        buttonText={buttonText}
+      />
+    </React.Fragment>
+  ))
+
+export default stories;

--- a/stories/pamphlet/index.js
+++ b/stories/pamphlet/index.js
@@ -21,7 +21,7 @@ stories.add('Rate Upgrades', () => (
       description={text('Description', description)}
       imageUrl={text('image URL', imageUrl)}
       buttonText={text('Button text', buttonText)}
-      handleClick={alertClick}
+      onButtonClick={alertClick}
     >
       <List>
         <p className={styles.listDescription}>{'⭐️ You will get:'}</p>

--- a/stories/pamphlet/index.js
+++ b/stories/pamphlet/index.js
@@ -20,7 +20,7 @@ stories
     <React.Fragment>
       <Pamphlet
         title={text('Title', title)}
-        price={priceText}
+        priceText={priceText}
         description={text('Description', description)}
         upgradeOptions={array('Upgrade options', upgradeOptions)}
         imageUrl={text('image URL', imageUrl)}

--- a/stories/pamphlet/index.js
+++ b/stories/pamphlet/index.js
@@ -2,31 +2,33 @@ import React from 'react';
 
 import { storiesOf } from '@storybook/react';
 import { array, text } from '@storybook/addon-knobs';
-
+import { List } from 'semantic-ui-react';
+import styles from '../../components/Pamphlet/Pamphlet.less';
 import { Pamphlet } from '../../components/Pamphlet/Pamphlet';
-import {
-  title,
-  priceText,
-  description,
-  imageUrl,
-  upgradeOptions,
-  buttonText
-} from './preview-variables';
+import { title, subtitle, description, imageUrl, upgradeOptions, buttonText } from './preview-variables';
 
 const stories = storiesOf('Pamphlet', module);
 
-stories
-  .add('Rate Upgrades', () => (
-    <React.Fragment>
-      <Pamphlet
-        title={text('Title', title)}
-        priceText={priceText}
-        description={text('Description', description)}
-        upgradeOptions={array('Upgrade options', upgradeOptions)}
-        imageUrl={text('image URL', imageUrl)}
-        buttonText={buttonText}
-      />
-    </React.Fragment>
-  ))
+stories.add('Rate Upgrades', () => (
+  <React.Fragment>
+    <Pamphlet
+      title={text('Title', title)}
+      subtitle={text('Subtitle', subtitle)}
+      description={text('Description', description)}
+      imageUrl={text('image URL', imageUrl)}
+      buttonText={buttonText}
+    >
+      <List>
+        <p className={styles.listDescription}>{'⭐️ You will get:'}</p>
+
+        <ul className={styles.listItems}>
+          {array('Upgrade options', upgradeOptions).map((option, i) => (
+            <li key={i}>{option}</li>
+          ))}
+        </ul>
+      </List>
+    </Pamphlet>
+  </React.Fragment>
+));
 
 export default stories;

--- a/stories/pamphlet/index.js
+++ b/stories/pamphlet/index.js
@@ -7,8 +7,8 @@ import { Pamphlet } from '../../components/Pamphlet/Pamphlet';
 
 const stories = storiesOf('Pamphlet', module);
 
-const header = "VIP ticket upgrade - Best experience"
-const price = 40.00
+const title = "VIP ticket upgrade - Best experience"
+const priceText = "Only $40.00 extra per ticket"
 const description = "🎉 Enhance your experience at the event!"
 const imageUrl = "https://www.tastingtable.com/img/gallery/11-cocktails-to-try-if-you-like-drinking-gin/intro-1640186734.webp"
 const upgradeOptions = [
@@ -28,8 +28,8 @@ stories
   .add('Rate Upgrades', () => (
     <React.Fragment>
       <Pamphlet
-        header={text("Header", header)}
-        price={price}
+        title={text("Title", title)}
+        price={priceText}
         description={text("Description", description)}
         upgradeOptions={array("Upgrade options", upgradeOptions)}
         imageUrl={text("image URL", imageUrl)}

--- a/stories/pamphlet/preview-variables.js
+++ b/stories/pamphlet/preview-variables.js
@@ -1,0 +1,16 @@
+export const title = "VIP ticket upgrade - Best experience"
+export const priceText = "Only $40.00 extra per ticket"
+export const description = "🎉 Enhance your experience at the event!"
+export const imageUrl = "https://www.tastingtable.com/img/gallery/11-cocktails-to-try-if-you-like-drinking-gin/intro-1640186734.webp"
+export const buttonText = "UPGRADE ALL TICKETS"
+export const upgradeOptions = [
+    "Priority access",
+    "Flexibility to arrive +/- 1hr of your time",
+    "Limited edition poster",
+    "greet and meetLimited edition cushion",
+    "VIP souvenir laminate",
+    "Priority access",
+    "Flexibility to arrive +/- 1hr of your time",
+    "Free available T-shirt while products last",
+    "Special seating"
+]

--- a/stories/pamphlet/preview-variables.js
+++ b/stories/pamphlet/preview-variables.js
@@ -1,16 +1,16 @@
-export const title = "VIP ticket upgrade - Best experience"
-export const priceText = "Only $40.00 extra per ticket"
-export const description = "🎉 Enhance your experience at the event!"
-export const imageUrl = "https://www.tastingtable.com/img/gallery/11-cocktails-to-try-if-you-like-drinking-gin/intro-1640186734.webp"
-export const buttonText = "UPGRADE ALL TICKETS"
+export const title = 'VIP ticket upgrade - Best experience'
+export const priceText = 'Only $40.00 extra per ticket'
+export const description = '🎉 Enhance your experience at the event!'
+export const imageUrl = 'https://www.tastingtable.com/img/gallery/11-cocktails-to-try-if-you-like-drinking-gin/intro-1640186734.webp'
+export const buttonText = 'UPGRADE ALL TICKETS'
 export const upgradeOptions = [
-    "Priority access",
-    "Flexibility to arrive +/- 1hr of your time",
-    "Limited edition poster",
-    "greet and meetLimited edition cushion",
-    "VIP souvenir laminate",
-    "Priority access",
-    "Flexibility to arrive +/- 1hr of your time",
-    "Free available T-shirt while products last",
-    "Special seating"
+    'Priority access',
+    'Flexibility to arrive +/- 1hr of your time',
+    'Limited edition poster',
+    'greet and meetLimited edition cushion',
+    'VIP souvenir laminate',
+    'Priority access',
+    'Flexibility to arrive +/- 1hr of your time',
+    'Free available T-shirt while products last',
+    'Special seating'
 ]

--- a/stories/pamphlet/preview-variables.js
+++ b/stories/pamphlet/preview-variables.js
@@ -1,5 +1,5 @@
 export const title = 'VIP ticket upgrade - Best experience'
-export const priceText = 'Only $40.00 extra per ticket'
+export const subtitle = 'Only $40.00 extra per ticket'
 export const description = '🎉 Enhance your experience at the event!'
 export const imageUrl = 'https://www.tastingtable.com/img/gallery/11-cocktails-to-try-if-you-like-drinking-gin/intro-1640186734.webp'
 export const buttonText = 'UPGRADE ALL TICKETS'


### PR DESCRIPTION
Initial mockup for the front-end code / design for our Rate Upgrades pamphlet.

In Storybook:

<img width="1127" alt="Screen Shot 2022-07-27 at 1 01 43 PM" src="https://user-images.githubusercontent.com/22895730/181306528-a4af94fb-11d3-409d-b16a-863c7118887b.png">

Design specs: [FIGMA](https://www.figma.com/file/qQ1bPeL2Y7KxcDa4uDY4hx/Upgrades-in-Checkout?node-id=2%3A91)

Resolves: [WEB-14683](https://universedev.atlassian.net/browse/WEB-14683)