### PR TITLE
Sidebar position unit change from vh to vw

### DIFF
--- a/components/Navbar/NavbarTabletMobile/NavbarTabletMobile.module.less
+++ b/components/Navbar/NavbarTabletMobile/NavbarTabletMobile.module.less
@@ -63,7 +63,7 @@
 }
 
 .sidebar {
-  left: -100vh;
+  left: -100vw;
   transition-timing-function: ease-in;
   transition: 0.2s;
   position: fixed;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "milkyway",
-  "version": "0.2.23",
+  "version": "0.2.22",
   "description": "Universe styles, as a semantic-ui theme",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "milkyway",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "Universe styles, as a semantic-ui theme",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary 🤔
**Issue**
when changing the orientation of the screen from portrait to landscape, the sidebar covers half of the screen even though the sidebar is supposed to be hidden from the screen.

**fix**
Changing the transform value for sidebar depending upon the viewport width rather than the height.

## Problem We're Solving 🐛
[Mobile View || While changing the screen orientation, the pages are getting overlapped.](https://universedev.atlassian.net/browse/WEB-16422)

## What you'll see
**Before**
<img width="944" alt="Screenshot 2023-08-03 at 12 03 42 PM" src="https://github.com/uniiverse/milkyway/assets/106646916/4ffbdaa8-d3b0-4d28-9626-e9ebd696f400">

**After**
<img width="944" alt="Screenshot 2023-08-03 at 11 58 52 AM" src="https://github.com/uniiverse/milkyway/assets/106646916/0bc1ac00-b807-40c4-8968-8eac0f59e41f">


## Pre-review checklist ✅
- [ ] Can anything be refactored into smaller, more reusable components?
- [ ] Is this feature always being used? If not, consider lazy loading the component.
- [ ] All the new files have typechecking enabled (`flow`)
- [ ] All new strings are internationalized (`yarn run manage:translations`)
- [ ] All the new svg files are optimized (`yarn run optimize`)

## Pre-merge checklist ✅

- [ ] QA Completed
- [ ] Dependent backend changes have been deployed

---

_*Thank you for taking the time to review this. Teamwork makes the dream work*_ 🏆✨
