### PR TITLE
fix: Pass through props to StyledDatePicker

### DIFF
--- a/components/DatePicker/DatePicker.jsx
+++ b/components/DatePicker/DatePicker.jsx
@@ -7,7 +7,7 @@ import 'react-dates/initialize';
 import 'react-dates/lib/css/_datepicker.css';
 import styles from './DatePicker.less';
 
-export const DatePicker = ({ date, highlightedDates, onDateChange, popupPosition='bottom left'}) => {
+export const DatePicker = ({ date, highlightedDates, onDateChange, popupPosition='bottom left', ...passthroughProps }) => {
   const [selectedDate, setSelectedDate] = useState(date);
   const [calendarOpen, setCalendarOpen] = useState(false);
   const calendarEl = useRef();
@@ -54,6 +54,7 @@ export const DatePicker = ({ date, highlightedDates, onDateChange, popupPosition
         <Popup.Content>
           <div ref={calendarEl}>
             <StyledDatePickerController
+              {...passthroughProps}
               className={styles.DatePicker}
               onDateChange={onDateSelect}
               highlightedDates={highlightedDates}

--- a/components/DatePicker/DatePicker.jsx
+++ b/components/DatePicker/DatePicker.jsx
@@ -20,8 +20,6 @@ export const DatePicker = ({ date, highlightedDates, onDateChange, popupPosition
     setCalendarOpen(false);
   }
   
-  console.log("DATEPICKER LOADED!");
-
   return(
     <div className="date-picker-container">
       

--- a/components/DatePicker/DatePicker.jsx
+++ b/components/DatePicker/DatePicker.jsx
@@ -19,7 +19,7 @@ export const DatePicker = ({ date, highlightedDates, onDateChange, popupPosition
     onDateChange(newDate);
     setCalendarOpen(false);
   }
-  
+
   return(
     <div className="date-picker-container">
       

--- a/components/DatePicker/DatePicker.jsx
+++ b/components/DatePicker/DatePicker.jsx
@@ -19,6 +19,8 @@ export const DatePicker = ({ date, highlightedDates, onDateChange, popupPosition
     onDateChange(newDate);
     setCalendarOpen(false);
   }
+  
+  console.log("DATEPICKER LOADED!");
 
   return(
     <div className="date-picker-container">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "milkyway",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "description": "Universe styles, as a semantic-ui theme",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Allows passing additional props into the `DatePicker`, which is an extension of `DayPickerSingleDateController` from `react-dates`.

Updates milkyway to `v0.2.25`